### PR TITLE
Improve build and integration processes

### DIFF
--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -2,9 +2,12 @@ name: build
 on:
   push:
     branches:
-      - main
+      - '*'
+      - '!main'
+  pull_request:
+
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,6 +23,3 @@ jobs:
 
       - name: Build documentation
         run: make build
-
-      - name: Deploy documentation
-        run: mkdocs gh-deploy --force --clean --verbose

--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -5,6 +5,8 @@ on:
       - '*'
       - '!main'
   pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,27 +1,22 @@
-name: build
+name: Build branches and PRs
 on:
   push:
-    branches:
-      - '*'
-      - '!main'
+    branches-ignore:
+      - 'main'
   pull_request:
     branches:
       - main
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
       - name: Install Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
-
       - name: Install MkDocs
         run: make install
-
       - name: Build documentation
         run: make build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,13 +7,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs
-      - run: pip install mkdocs-material
-      - run: pip install mkdocs-include-markdown-plugin
-      - run: pip install mkdocs-git-revision-date-localized-plugin
-      - run: mkdocs gh-deploy --force --clean --verbose
 
+      - name: Install MkDocs
+        run: make install
+
+      - name: Deploy documentation
+        run: mkdocs gh-deploy --force --clean --verbose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,17 +9,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
       - name: Install Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
-
       - name: Install MkDocs
         run: make install
-
       - name: Build documentation
         run: make build
-
       - name: Deploy documentation
         run: mkdocs gh-deploy --force --clean --verbose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: build
+name: Build and deploy main
 on:
   push:
     branches:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY:  install build serve
+
+install:
+		pip install mkdocs
+		pip install mkdocs-material
+		pip install mkdocs-include-markdown-plugin
+		pip install mkdocs-git-revision-date-localized-plugin
+
+build:
+		mkdocs build
+
+serve:
+		mkdocs serve

--- a/README.md
+++ b/README.md
@@ -5,26 +5,39 @@ overview of the security risks in cross-chain protocols by identifying,
 classifying, and analyzing the elements of risk inherent in the design,
 implementation and operation of such infrastructure. In addition, it
 profers a set of risk-controls and best practices to mitigate the
-likelihood and magnitude of various risks.
+likelihood and magnitude of various risks. This repository holds the source code behind the website.
 
-This repo holds the source code behind the website
-https://crosschainriskframework.github.io/ . The deployed website is based on the files on the `main` branch in this repository. The website code is generated using GitHub actions and committed on the `gh-pages` branch. Do not edit files in the `gh-pages` branch as
-these files are overwritten each time a new PR is merged to the `main` branch.
+### Local Build
+[MkDocs](https://www.mkdocs.org/) is used to generate the documentation pages from the markdown files in this repository.
 
+#### Prerequisites
+- Python 3.x.x
 
-### Build
 #### Install dependencies
-- prerequisites: Python 3.x.x
-- run `make install`
+Clone this repo, then `cd` into it and execute:
+```
+ make install
+```
 
-#### Build Documentation
-- run `make build`
+#### Build documentation
+To build the documentation using MkDocs, execute the following :
+```
+make build
+```
 
-#### Serve Documentation Locally
-To view the documentation locally execute the command below. This will build and serve the documentation site locally, and automatically update the site if the underlying files are changed.
-- run `make serve`
-- open browser to http://127.0.0.1:8000/
+#### Serve documentation locally
+To view the documentation locally using MkDocs execute the command below. This will build and serve the documentation site locally, and automatically update the site if the underlying files are changed .
+```
+make serve
+```
+Then, open browser to http://127.0.0.1:8000/
 
-### How to Contribute
+### Remote deployment
+The website is automatically updated when new commits are pushed to the `main` branch. More specifically, the documentation site is generated from the updated source code on the `main` branch, and then committed to the `gh-pages` branch using Github actions. The updated files in `gh-pages` are then automatically [deployed](https://crosschainriskframework.github.io/).
+
+*Note: do not edit files in the `gh-pages` branch as these files are overwritten each time a new PR is merged to the `main` branch.*
+
+
+### How to contribute
 See the [Contribution](https://crosschainriskframework.github.io/authors/contributions/)
 section of the website.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To view the documentation locally using MkDocs execute the command below. This w
 ```
 make serve
 ```
-Then, open browser to http://127.0.0.1:8000/
+Then open a browser with the following address: http://127.0.0.1:8000/
 
 ### Remote deployment
 The website is automatically updated when new commits are pushed to the `main` branch. More specifically, the documentation site is generated from the updated source code on the `main` branch, and then committed to the `gh-pages` branch using Github actions. The updated files in `gh-pages` are then automatically [deployed](https://crosschainriskframework.github.io/).

--- a/README.md
+++ b/README.md
@@ -1,37 +1,30 @@
 # Crosschain Risk Framework
 
-This repo holds the source code behind 
-https://crosschainriskframework.github.io/ .
+The [Crosschain Risk Framework](https://crosschainriskframework.github.io/) website provides a high-level systematic
+overview of the security risks in cross-chain protocols by identifying,
+classifying, and analyzing the elements of risk inherent in the design,
+implementation and operation of such infrastructure. In addition, it
+profers a set of risk-controls and best practices to mitigate the
+likelihood and magnitude of various risks.
 
-The [Crosschain Risk Framework](https://crosschainriskframework.github.io/) website provides a high-level systematic 
-overview of the security risks in cross-chain protocols by identifying, 
-classifying, and analyzing the elements of risk inherent in the design, 
-implementation and operation of such infrastructure. In addition, it 
-profers a set of risk-controls and best practices to mitigate the 
-likelihood and magnitude of various risks. 
+This repo holds the source code behind the website
+https://crosschainriskframework.github.io/ . The deployed website is based on the files on the `main` branch in this repository. The website code is generated using GitHub actions and committed on the `gh-pages` branch. Do not edit files in the `gh-pages` branch as
+these files are overwritten each time a new PR is merged to the `main` branch.
 
 
-## Authors, How to Contribute, Code of Conduct and CLA
-See the [Contribution](https://crosschainriskframework.github.io/authors/contributions/) 
+### Build
+#### Install dependencies
+- prerequisites: Python 3.x.x
+- run `make install`
+
+#### Build Documentation
+- run `make build`
+
+#### Serve Documentation Locally
+To view the documentation locally execute the command below. This will build and serve the documentation site locally, and automatically update the site if the underlying files are changed.
+- run `make serve`
+- open browser to http://127.0.0.1:8000/
+
+### How to Contribute
+See the [Contribution](https://crosschainriskframework.github.io/authors/contributions/)
 section of the website.
-
-
-
-## Building
-To build and run the website locally:
-
-* Install python
-* Install mkdocs
-* Install all of the mkdocs packages in the file ./.github/workflows/main.yml
-* Execute ```mkdocs serve```
-* Open a web browser to http://127.0.0.1:8000/
-
-The website tracks changes as they are made. 
-
-The deployed website is based on the files on the **main** branch on GitHub. 
-The website code is generated using GitHub actions and committed on the 
-**gh-pages** branch. Do not edit files in the **gh-pages** branch as 
-these files are overwritten each time a new PR is merged to the **main** branch. 
-
-
- 


### PR DESCRIPTION
This PR makes the following minor improvements to the build and integration processes of this project:
- add a simple `Make` file that simplifies setting up, building, and locally hosting the documentation 
- updates README in line with the above change
- configures Github action workflows that build and check branches and pull requests