### PR TITLE
Initial attempt at PDF generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ fonts/
 search/
 sitemap*
 *html
+CrosschainRiskFramework.pdf

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ install:
 		pip install mkdocs-material
 		pip install mkdocs-include-markdown-plugin
 		pip install mkdocs-git-revision-date-localized-plugin
+		pip install weasyprint
 
 build:
 		mkdocs build

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ install:
 		pip install mkdocs-include-markdown-plugin
 		pip install mkdocs-git-revision-date-localized-plugin
 		pip install weasyprint
+		pip install mkdocs-with-pdf
 
 build:
 		mkdocs build

--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ Clone this repo, then `cd` into it and execute:
 ```
 
 #### Build documentation
-To build the documentation using MkDocs, execute the following :
+To build the documentation using MkDocs, execute the following:
 ```
 make build
 ```
+In addition to building the website, this will generate a copy of the website in PDF format.
 
 #### Serve documentation locally
 To view the documentation locally using MkDocs execute the command below. This will build and serve the documentation site locally, and automatically update the site if the underlying files are changed .
@@ -36,12 +37,6 @@ Then open a browser with the following address: http://127.0.0.1:8000/
 The website is automatically updated when new commits are pushed to the `main` branch. More specifically, the documentation site is generated from the updated source code on the `main` branch, and then committed to the `gh-pages` branch using Github actions. The updated files in `gh-pages` are then automatically [deployed](https://crosschainriskframework.github.io/).
 
 *Note: do not edit files in the `gh-pages` branch as these files are overwritten each time a new PR is merged to the `main` branch.*
-
-### Generating a PDF version of the Crosschain Risk Framework
-To generate a PDF file of the website, first install [Weasyprint](https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#installation). Then execute the command:
-```
-make build
-```
 
 ### How to contribute
 See the [Contribution](https://crosschainriskframework.github.io/authors/contributions/)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ The website is automatically updated when new commits are pushed to the `main` b
 
 *Note: do not edit files in the `gh-pages` branch as these files are overwritten each time a new PR is merged to the `main` branch.*
 
+### Generating a PDF version of the Crosschain Risk Framework
+To generate a PDF file of the website, first install [Weasyprint](https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#installation). Then execute the command:
+```
+make build
+```
 
 ### How to contribute
 See the [Contribution](https://crosschainriskframework.github.io/authors/contributions/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ plugins:
         copyright: Copyright &copy; 2022 Crosschain Risk Framework Authors
         cover_subtitle: PDF version of https://crosschainriskframework.github.io/
         output_path: ../CrosschainRiskFramework.pdf
-        toc_level: 3
+        toc_level: 0
   - include-markdown
   - search
   - git-revision-date-localized:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ theme:
 plugins:
 # https://pypi.org/project/mkdocs-with-pdf/
   - with-pdf:
+        author: Crosschain Risk Framework Authors (see Authors and Contributing section)
         copyright: Copyright &copy; 2022 Crosschain Risk Framework Authors
         cover_subtitle: PDF version of https://crosschainriskframework.github.io/
         output_path: ../CrosschainRiskFramework.pdf

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,12 @@ theme:
     - toc.integrate
     - toc.follow
 plugins:
+# https://pypi.org/project/mkdocs-with-pdf/
+  - with-pdf:
+        copyright: Copyright &copy; 2022 Crosschain Risk Framework Authors
+        cover_subtitle: PDF version of https://crosschainriskframework.github.io/
+        output_path: ../CrosschainRiskFramework.pdf
+        toc_level: 3
   - include-markdown
   - search
   - git-revision-date-localized:


### PR DESCRIPTION
Add the ability to generate a PDF file from the mkdocs content. 

There are some errors generated when the PDF file is generated, indicating some internal links the tool believes are broken. The table of contents side bar is generated correctly. However, the table of contents page is not generated correctly. 

This PR should be viewed as a starting point, from which we could improve the PDF output. 