### PR TITLE
Display Github details in doc header

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,8 @@ strict: true
 repo_url: https://github.com/CrosschainRiskFramework/CrosschainRiskFramework.github.io
 theme:
   name: material
+  icon:
+    repo: fontawesome/brands/github-alt
   features:
     - navigation.expand
     - navigation.tracking

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ strict: true
 # For documentation on the mkdocs configuration see:
 # mkdocs: https://www.mkdocs.org/user-guide/configuration/
 # Material theme: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/
+repo_url: https://github.com/CrosschainRiskFramework/CrosschainRiskFramework.github.io
 theme:
   name: material
   features:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ strict: true
 # mkdocs: https://www.mkdocs.org/user-guide/configuration/
 # Material theme: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/
 repo_url: https://github.com/CrosschainRiskFramework/CrosschainRiskFramework.github.io
+edit_uri: blob/main/docs/
 theme:
   name: material
   icon:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ repo_url: https://github.com/CrosschainRiskFramework/CrosschainRiskFramework.git
 theme:
   name: material
   icon:
-    repo: fontawesome/brands/github-alt
+    repo: fontawesome/brands/github
   features:
     - navigation.expand
     - navigation.tracking


### PR DESCRIPTION
This PR enables the prominent display of the GitHub details of this repository on the top bar of the doc pages. 