### PR TITLE
Fix build error for include-markdown

### DIFF
--- a/docs/authors/contributions.md
+++ b/docs/authors/contributions.md
@@ -1,6 +1,6 @@
 # Authors and Contributing
 
-{% include-markdown "authors.md" %}
-{% include-markdown "committee.md" %}
-{% include-markdown "code-of-conduct.md" %}
-{% include-markdown "contributing.md" %}
+{% include-markdown "./authors.md" %}
+{% include-markdown "./committee.md" %}
+{% include-markdown "./code-of-conduct.md" %}
+{% include-markdown "./contributing.md" %}

--- a/docs/framework/20categories/20architecture/architecture.md
+++ b/docs/framework/20categories/20architecture/architecture.md
@@ -7,8 +7,8 @@ Risks that stem from the security properties, assumptions, trade-offs, and limit
 </figure>
 
 
-{% include-markdown "messaging.md" %}
-{% include-markdown "coordination.md" %}
-{% include-markdown "token-bridges.md" %}
-{% include-markdown "liquidity-networks.md" %}
-{% include-markdown "bridge-aggregation-protocols.md" %}
+{% include-markdown "./messaging.md" %}
+{% include-markdown "./coordination.md" %}
+{% include-markdown "./token-bridges.md" %}
+{% include-markdown "./liquidity-networks.md" %}
+{% include-markdown "./bridge-aggregation-protocols.md" %}

--- a/docs/framework/20categories/30implementation/protocol-implementation-risk.md
+++ b/docs/framework/20categories/30implementation/protocol-implementation-risk.md
@@ -22,28 +22,28 @@ The rest of this section will discuss specific practices and considerations that
 ***
 ## Reducing Risk
 
-{% include-markdown "mixing-control-data-flow.md" %}
-{% include-markdown "access-control.md" %}
-{% include-markdown "upgrade.md" %}
-{% include-markdown "secret-storage.md" %}
-{% include-markdown "maturity.md" %}
-{% include-markdown "known-platform.md" %}
-{% include-markdown "known-language.md" %}
+{% include-markdown "./mixing-control-data-flow.md" %}
+{% include-markdown "./access-control.md" %}
+{% include-markdown "./upgrade.md" %}
+{% include-markdown "./secret-storage.md" %}
+{% include-markdown "./maturity.md" %}
+{% include-markdown "./known-platform.md" %}
+{% include-markdown "./known-language.md" %}
 
 ***
 ## Uncovering Extant Risk
-{% include-markdown "formal-verification.md" %}
-{% include-markdown "testing.md" %}
-{% include-markdown "audit.md" %}
-{% include-markdown "open-source.md" %}
-{% include-markdown "verified-code.md" %}
-{% include-markdown "documentation.md" %}
-{% include-markdown "bug-bounty.md" %}
+{% include-markdown "./formal-verification.md" %}
+{% include-markdown "./testing.md" %}
+{% include-markdown "./audit.md" %}
+{% include-markdown "./open-source.md" %}
+{% include-markdown "./verified-code.md" %}
+{% include-markdown "./documentation.md" %}
+{% include-markdown "./bug-bounty.md" %}
 
 ***
 ## Responding to Materialized Risk
-{% include-markdown "pause.md" %}
-{% include-markdown "ban-address.md" %}
+{% include-markdown "./pause.md" %}
+{% include-markdown "./ban-address.md" %}
 
 
 

--- a/docs/framework/20categories/40operation/protocol-operation-risk.md
+++ b/docs/framework/20categories/40operation/protocol-operation-risk.md
@@ -1,9 +1,9 @@
 # Protocol Operation Risk
 
-{% include-markdown "operational-security.md" %}
-{% include-markdown "ability-pause.md" %}
-{% include-markdown "diversity-code.md" %}
-{% include-markdown "decentralization.md" %}
-{% include-markdown "offchain-security.md" %}
-{% include-markdown "vulnerability.md" %}
+{% include-markdown "./operational-security.md" %}
+{% include-markdown "./ability-pause.md" %}
+{% include-markdown "./diversity-code.md" %}
+{% include-markdown "./decentralization.md" %}
+{% include-markdown "./offchain-security.md" %}
+{% include-markdown "./vulnerability.md" %}
 

--- a/docs/framework/30scoring/scoring.md
+++ b/docs/framework/30scoring/scoring.md
@@ -10,13 +10,12 @@ A project is likely to receive different scores over time. Based on this risk fr
 
 Determining the trustworthiness of one crosschain protocol relative to other protocols is an extremely complex task. This risk score model below is just a very preliminary step. Please provide feedback to help us improve this scoring system.
 
-{% include-markdown "overview.md" %}
+{% include-markdown "./overview.md" %}
 
-{% include-markdown "network.md" %}
+{% include-markdown "./network.md" %}
 
-{% include-markdown "architecture.md" %}
+{% include-markdown "./architecture.md" %}
 
-{% include-markdown "implementation.md" %}
+{% include-markdown "./implementation.md" %}
 
-{% include-markdown "operational.md" %}
-
+{% include-markdown "./operational.md" %}


### PR DESCRIPTION
Found in the following files, after running mkdocs build, that a build error would occur due to . Solution is to provide relative file path for these commands

- docs/authors/contributions.md
- docs/framework/20categories/20architecture/architecture.md
- docs/framework/20categories/30implementation/protocol-implementation-risk.md
- docs/framework/20categories/40operation/protocol-operation-risk.md
- docs/framework/30scoring.md

Visually local version appears equivalent to the public site at https://crosschainriskframework.github.io